### PR TITLE
Upgrade to dotnetcore 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ cd mtproto-proxy
 ```
 
 ## Build project
+navigate to the **tgsocks** folder and run these commands
 ```
 dotnet restore src
 dotnet build src -c Release
@@ -34,6 +35,4 @@ vi src/tgsocks/config.json
 ```
 
 ## Start proxy
-```
-dotnet src/tgsocks/bin/Release/netcoreapp2.0/tgsocks.dll src/tgsocks/config.json
-```
+simply click on **tgsocks.exe**

--- a/src/MTProto/MTProto.csproj
+++ b/src/MTProto/MTProto.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tgsocks/tgsocks.csproj
+++ b/src/tgsocks/tgsocks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>tgsocks</AssemblyName>
   </PropertyGroup>
 


### PR DESCRIPTION
It will be amazing if **freepvps/Mtproto** use **dotnetcore 3.1** with the long time support.👍 

here are the reasons to continue **freepvps/Mtproto** parallel with the **official telegram mtproto**.
- the official telegram mtproto uses the docker which cannot be installed on old windows servers (below 2016). read [here](https://docs.docker.com/ee/docker-ee/windows/docker-ee) and [here](https://forums.docker.com/t/windows-server-2012-r2/24267/2)
- users cannot install the windows server 2016 or above on the cheap VPS with weak software

here are the reasons for this PR 
- netcore3 make a single exe file to run easier
- netcore 2.x is not supported any more